### PR TITLE
feature/f2017280101-make-the-project-use-a-configuration-file-for-var…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*
+!*/
+!*.*
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
+	"github.com/spf13/viper"
+	"github.com/veskoy/gomas/utilities"
 )
 
 var (
@@ -15,6 +18,18 @@ var (
 func init() {
 	flag.StringVar(&ServerIP, "ip", "127.0.0.1", "The IP address the server will listen on.")
 	flag.StringVar(&ServerPort, "port", "27010", "The port the server will use.")
+}
+
+// ConfigSetup sets up Viper for easier configuration management.
+func ConfigSetup() {
+	viper.SetConfigName("config") // name of config file (without extension)
+	viper.AddConfigPath("../")    // look for config file in the parent directory
+	viper.AddConfigPath(".")      // look for config file in the current directory
+
+	if err := viper.ReadInConfig(); err != nil {
+		formattedError := errors.New("Fatal error config file: %s \n" + err.Error())
+		utilities.PanicOnError(&formattedError)
+	}
 }
 
 // FlagArguments parses the command line flag arguments provided to the executable.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/spf13/viper"
+	"github.com/veskoy/gomas/utilities"
 	"os"
 	"testing"
 )
@@ -20,5 +22,20 @@ func TestCustomFlagArguments(t *testing.T) {
 
 	if ServerIP != "192.168.1.100" || ServerPort != "27013" {
 		t.Errorf("Expected flag values were '%s' and '%s' but got '%s' and '%s'.", "192.168.1.100", "27013", ServerIP, ServerPort)
+	}
+}
+
+func TestConfigSetup(t *testing.T) {
+	utilities.AssertNoPanic(t, func() { ConfigSetup() })
+}
+
+func TestConfigRead(t *testing.T) {
+	ConfigSetup()
+
+	value1 := viper.GetString("db.mysql.host")
+	value2 := viper.GetString("db.sqlite.filepath")
+
+	if value1 != "localhost" && value2 != "/tmp/Gomas.db" {
+		t.Errorf("The setting wasn't fetched from the config file.")
 	}
 }

--- a/cmd/gomasd/main.go
+++ b/cmd/gomasd/main.go
@@ -6,6 +6,7 @@ import (
 )
 
 func main() {
+	cmd.ConfigSetup()
 	cmd.FlagArguments()
 	server.Listen()
 }

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,9 @@
+db:
+  mysql:
+    host: localhost
+    user: root
+    pass:
+    port: 3306
+
+  sqlite:
+    filepath: /tmp/Gomas.db

--- a/server/server.go
+++ b/server/server.go
@@ -11,10 +11,10 @@ import (
 // Listen starts the Master Server.
 func Listen() {
 	ServerAddr, err := net.ResolveUDPAddr("udp", cmd.ServerIP+":"+cmd.ServerPort)
-	utilities.ExitOnError(&err)
+	utilities.PanicOnError(&err)
 
 	ServerConn, err := net.ListenUDP("udp", ServerAddr)
-	utilities.ExitOnError(&err)
+	utilities.PanicOnError(&err)
 
 	defer ServerConn.Close()
 

--- a/utilities/test_helpers.go
+++ b/utilities/test_helpers.go
@@ -1,0 +1,25 @@
+package utilities
+
+import (
+	"testing"
+)
+
+// AssertPanic expects function's execution to result in panic.
+func AssertPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}
+
+// AssertNoPanic expects function's execution to NOT result in panic.
+func AssertNoPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("The code did panic")
+		}
+	}()
+	f()
+}

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -2,7 +2,6 @@ package utilities
 
 import (
 	"fmt"
-	"os"
 )
 
 // CheckError checks whether an error occurred and prints it to the command line.
@@ -12,11 +11,10 @@ func CheckError(err *error) {
 	}
 }
 
-// ExitOnError checks whether an error occurred and prints it to the command line.
+// PanicOnError checks whether an error occurred and prints it to the command line.
 // It also sends an exit code to the OS.
-func ExitOnError(err *error) {
+func PanicOnError(err *error) {
 	if *err != nil {
-		fmt.Println("A critical error occurred:", *err)
-		os.Exit(0)
+		panic("A critical error occurred: \n" + (*err).Error())
 	}
 }

--- a/utilities/utilities_test.go
+++ b/utilities/utilities_test.go
@@ -2,6 +2,7 @@ package utilities
 
 import (
 	"errors"
+	"testing"
 )
 
 func ExampleCheckError_withError() {
@@ -16,14 +17,12 @@ func ExampleCheckError_withoutError() {
 	// Output:
 }
 
-func ExampleExitOnError() {
+func TestPanicOnError(t *testing.T) {
 	err := errors.New("A sample error")
-	ExitOnError(&err)
-	// Output: A critical error occurred: A sample error
+	AssertPanic(t, func() { PanicOnError(&err) })
 }
 
-func ExampleExitOnError_withoutError() {
+func TestPanicOnError_withoutError(t *testing.T) {
 	var err error
-	ExitOnError(&err)
-	// Output:
+	AssertNoPanic(t, func() { PanicOnError(&err) })
 }


### PR DESCRIPTION
**Description:**
- Changed helper to panic instead of return error code.
- Updated related utilities tests.
- Changed helper usage in other files.
- Added Viper for easier configuration management.
- Added tests covering configuration initialization.

**Related issue:**
Closes #16 
